### PR TITLE
Add details about entry `data`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Under `ssb.conn.*` you can call any of these APIs in your local peer.
 |-----|------|-------------|
 | **`remember(addr, data?)`** | `sync` | Stores (in cold storage) connection information about a new peer, known by its multiserver address `addr` and additional optional `data` (as an object). |
 | **`forget(addr)`** | `sync` | Removes (from cold storage) connection information about a peer known by its multiserver address `addr`. |
-| **`dbPeers()`** | `sync` | Returns an Iterable of (cold stored) database "entries" (see definition below) known at the moment. Does not reactively update once the database is written to. |
+| **`dbPeers()`** | `sync` | Returns an Iterable of ConnDB entries known at the moment. Does not reactively update once the database is written to. |
 | **`connect(addr, data?)`** | `async` | Connects to a peer known by its multiserver address `addr`, and stores additional optional `data` (as an object) during its connection lifespan. |
 | **`disconnect(addr)`** | `async` | Disconnects a peer known by its multiserver address `addr`. |
-| **`peers()`** | `source` | A pull-stream that emits an array of all connection "entries" (see definition below) whenever any connection updates (changes it state: connecting, disconnecting, connected, etc). |
+| **`peers()`** | `source` | A pull-stream that emits an array of all ConnHub entries whenever any connection updates (i.e. changes it state: connecting, disconnecting, connected, etc). |
 | **`stage(addr, data?)`** | `sync` | Registers a suggested connection to a new peer, known by its multiserver address `addr` and additional optional `data` (as an object). |
 | **`unstage(addr)`** | `sync` | Unregisters a suggested connection the peer known by its multiserver address `addr`. |
-| **`stagedPeers()`** | `source` | A pull-stream that emits an array of all staged "entries" (see definition below) whenever any staging status updates (upon stage() or unstage()). |
+| **`stagedPeers()`** | `source` | A pull-stream that emits an array of all ConnStaging entries whenever any staging status updates (upon stage() or unstage()). |
 | **`start()`** | `sync` | Triggers the start of the connection scheduler in CONN. |
 | **`stop()`** | `sync` | Stops the CONN scheduler if it is currently active. |
 | **`ping()`** | `duplex` | A duplex pull-stream for periodically pinging with peers, fully compatible with `ssb.gossip.ping`. |

--- a/README.md
+++ b/README.md
@@ -72,25 +72,27 @@ An "entry" is a (tuple) array of form:
 [addr, data]
 ```
  where: 
- - `addr` (String) is a multiserver address (string that [follows some rules](https://github.com/dominictarr/multiserver-address))
- - `data` (Object) contains additional information, depending on the method:
-
-   - `peers()` data:
-     - `key` - the peers public key / feedId
-     - `hubBirth` - unix time for when this peer was asdded to the hub
-     - `hubUpdated` - unix time for when this peer was last updated
-     - `state` - `(connecting | connected | disconnecting)`
-     - `inferredType` - `(lan | ???)`
-   - `stagedPeers()` data:
-     - `key` - the peers public key / feedId
-     - `autoconnect` - boolean about whether to connect automatically
-     - `birth` - unix time ... ???
-     - `stagingBirth`  - unix time for when this peer became known of
-     - `stagingUpdated` - unix time for when this peer was last updated
-     - `pool` - where this peer was discovered `(db | ???)`
-     - `type` - what type of peer `(pub | ???)`
-   - `dbPeers()` data: ??? same as `peers()` ???
-
+ - `addr` is a multiserver address (a **string** that [follows some rules](https://github.com/dominictarr/multiserver-address))
+ - `data` is an **object** with additional information about the peer (fields marked 🔷 are important and often used, fields marked 🔹 come from CONN, fields marked 🔸 are ad-hoc and added by various other modules, and fields suffixed with `?` are not always present):
+   - 🔷 `key: string`: the peer's public key / feedId
+   - 🔷 `state?: 'connecting' | 'connected' | 'disconnecting'`: (only from `peers()`) the peer's current connection status
+   - 🔷 `type?: string`: what type of peer this is; it can be any string, but often is either `'lan'`, `'bt'`, `'pub'`, `'room'`, `'room-endpoint'`, `'dht'`
+   - 🔹 `inferredType?: 'bt' | 'lan' | 'dht' | 'internet' | 'tunnel'`: (only from `peers()`) when there is no `type` field, e.g. when a new and unknown peer initiates a client connection with us (as a server), then ConnHub makes a guess what type it is
+   - 🔹 `birth?: number`: Unix timestamp for when this peer was added to ConnDB
+   - 🔹 `stateChange?: number`: Unix timestamp for the last time the field `state` was changed; this is stored in ConnDB
+   - 🔹 `hubBirth?: number`: Unix timestamp for when this peer was added to ConnHub
+   - 🔹 `hubUpdated?: number`: Unix timestamp for when this data object was last updated in ConnHub
+   - 🔹 `stagingBirth?: number`: Unix timestamp for when this peer was added to ConnStaging
+   - 🔹 `stagingUpdated?: number`: Unix timestamp for when this data object was last updated in ConnStaging
+   - 🔹 `autoconnect?: boolean`: indicates whether this peer should be considered for connection in the scheduler
+   - 🔹 `failure?: number`: typically in ConnDB, this is the number of connection errors since the last successful connection
+   - 🔹 `duration?: object`: typically in ConnDB, this is a [statistics](https://www.npmjs.com/package/statistics) object to measure the duration of connection with this peer
+   - 🔹 `ping?: object`: typically in ConnDB, this is [statistics](https://www.npmjs.com/package/statistics) object of various ping health measurements
+   - 🔹 `pool?: 'db' | 'hub' | 'staging'`: this only appears in ConnQuery APIs, and indicates from which pool (ConnDB or ConnHub or ConnStaging) was this peer picked
+   - 🔸 `name?: string`: a nickname for this peer, when there isn't an [ssb-about](https://github.com/ssbc/ssb-about) name
+   - 🔸 `room?: string`: (only if `type = 'room-endpoint'`) the public key of the [room](https://github.com/staltz/ssb-room) server where this peer is in
+   - 🔸 `onlineCount?: number`: (only if `type = 'room'`) the number of room endpoints currently connected to this room
+   
 ## Gossip compatibility
 
 The following gossip plugin APIs are available once you install CONN, but **these will emit deprecation warnings and might behave slightly different than the old gossip plugin**:

--- a/README.md
+++ b/README.md
@@ -66,11 +66,30 @@ Under `ssb.conn.*` you can call any of these APIs in your local peer.
 | **`staging()`** | `sync` | Returns the instance of [ConnStaging](https://github.com/staltz/ssb-conn-staging) currently in use. |
 | **`query()`** | `sync` | Returns the instance of [ConnQuery](https://github.com/staltz/ssb-conn-query) currently in use. |
 
-An "entry" is a (tuple) array with a multiserver address (string that [follows some rules](https://github.com/dominictarr/multiserver-address)) and data (an object):
+An "entry" is a (tuple) array of form:
 
 ```javascript
 [addr, data]
 ```
+ where: 
+ - `addr` (String) is a multiserver address (string that [follows some rules](https://github.com/dominictarr/multiserver-address))
+ - `data` (Object) contains additional information, depending on the method:
+
+   - `peers()` data:
+     - `key` - the peers public key / feedId
+     - `hubBirth` - unix time for when this peer was asdded to the hub
+     - `hubUpdated` - unix time for when this peer was last updated
+     - `state` - `(connecting | connected | disconnecting)`
+     - `inferredType` - `(lan | ???)`
+   - `stagedPeers()` data:
+     - `key` - the peers public key / feedId
+     - `autoconnect` - boolean about whether to connect automatically
+     - `birth` - unix time ... ???
+     - `stagingBirth`  - unix time for when this peer became known of
+     - `stagingUpdated` - unix time for when this peer was last updated
+     - `pool` - where this peer was discovered `(db | ???)`
+     - `type` - what type of peer `(pub | ???)`
+   - `dbPeers()` data: ??? same as `peers()` ???
 
 ## Gossip compatibility
 

--- a/README.md
+++ b/README.md
@@ -74,24 +74,42 @@ An "entry" is a (tuple) array of form:
  where: 
  - `addr` is a multiserver address (a **string** that [follows some rules](https://github.com/dominictarr/multiserver-address))
  - `data` is an **object** with additional information about the peer (fields marked 🔷 are important and often used, fields marked 🔹 come from CONN, fields marked 🔸 are ad-hoc and added by various other modules, and fields suffixed with `?` are not always present):
-   - 🔷 `key: string`: the peer's public key / feedId
-   - 🔷 `state?: 'connecting' | 'connected' | 'disconnecting'`: (only from `peers()`) the peer's current connection status
-   - 🔷 `type?: string`: what type of peer this is; it can be any string, but often is either `'lan'`, `'bt'`, `'pub'`, `'room'`, `'room-endpoint'`, `'dht'`
-   - 🔹 `inferredType?: 'bt' | 'lan' | 'dht' | 'internet' | 'tunnel'`: (only from `peers()`) when there is no `type` field, e.g. when a new and unknown peer initiates a client connection with us (as a server), then ConnHub makes a guess what type it is
-   - 🔹 `birth?: number`: Unix timestamp for when this peer was added to ConnDB
-   - 🔹 `stateChange?: number`: Unix timestamp for the last time the field `state` was changed; this is stored in ConnDB
-   - 🔹 `hubBirth?: number`: Unix timestamp for when this peer was added to ConnHub
-   - 🔹 `hubUpdated?: number`: Unix timestamp for when this data object was last updated in ConnHub
-   - 🔹 `stagingBirth?: number`: Unix timestamp for when this peer was added to ConnStaging
-   - 🔹 `stagingUpdated?: number`: Unix timestamp for when this data object was last updated in ConnStaging
-   - 🔹 `autoconnect?: boolean`: indicates whether this peer should be considered for connection in the scheduler
-   - 🔹 `failure?: number`: typically in ConnDB, this is the number of connection errors since the last successful connection
-   - 🔹 `duration?: object`: typically in ConnDB, this is a [statistics](https://www.npmjs.com/package/statistics) object to measure the duration of connection with this peer
-   - 🔹 `ping?: object`: typically in ConnDB, this is [statistics](https://www.npmjs.com/package/statistics) object of various ping health measurements
-   - 🔹 `pool?: 'db' | 'hub' | 'staging'`: this only appears in ConnQuery APIs, and indicates from which pool (ConnDB or ConnHub or ConnStaging) was this peer picked
-   - 🔸 `name?: string`: a nickname for this peer, when there isn't an [ssb-about](https://github.com/ssbc/ssb-about) name
-   - 🔸 `room?: string`: (only if `type = 'room-endpoint'`) the public key of the [room](https://github.com/staltz/ssb-room) server where this peer is in
-   - 🔸 `onlineCount?: number`: (only if `type = 'room'`) the number of room endpoints currently connected to this room
+
+🔷 `key: string`: the peer's public key / feedId
+
+🔷 `state?: 'connecting' | 'connected' | 'disconnecting'`: (only from `peers()`) the peer's current connection status
+
+🔷 `type?: string`: what type of peer this is; it can be any string, but often is either `'lan'`, `'bt'`, `'pub'`, `'room'`, `'room-endpoint'`, `'dht'`
+
+🔹 `inferredType?: 'bt' | 'lan' | 'dht' | 'internet' | 'tunnel'`: (only from `peers()`) when there is no `type` field, e.g. when a new and unknown peer initiates a client connection with us (as a server), then ConnHub makes a guess what type it is
+
+🔹 `birth?: number`: Unix timestamp for when this peer was added to ConnDB
+
+🔹 `stateChange?: number`: Unix timestamp for the last time the field `state` was changed; this is stored in ConnDB
+
+🔹 `hubBirth?: number`: Unix timestamp for when this peer was added to ConnHub
+
+🔹 `hubUpdated?: number`: Unix timestamp for when this data object was last updated in ConnHub
+
+🔹 `stagingBirth?: number`: Unix timestamp for when this peer was added to ConnStaging
+
+🔹 `stagingUpdated?: number`: Unix timestamp for when this data object was last updated in ConnStaging
+
+🔹 `autoconnect?: boolean`: indicates whether this peer should be considered for connection in the scheduler
+
+🔹 `failure?: number`: typically in ConnDB, this is the number of connection errors since the last successful connection
+
+🔹 `duration?: object`: typically in ConnDB, this is a [statistics](https://www.npmjs.com/package/statistics) object to measure the duration of connection with this peer
+
+🔹 `ping?: object`: typically in ConnDB, this is [statistics](https://www.npmjs.com/package/statistics) object of various ping health measurements
+
+🔹 `pool?: 'db' | 'hub' | 'staging'`: this only appears in ConnQuery APIs, and indicates from which pool (ConnDB or ConnHub or ConnStaging) was this peer picked
+
+🔸 `name?: string`: a nickname for this peer, when there isn't an [ssb-about](https://github.com/ssbc/ssb-about) name
+
+🔸 `room?: string`: (only if `type = 'room-endpoint'`) the public key of the [room](https://github.com/staltz/ssb-room) server where this peer is in
+
+🔸 `onlineCount?: number`: (only if `type = 'room'`) the number of room endpoints currently connected to this room
    
 ## Gossip compatibility
 


### PR DESCRIPTION
I found myself console.logging to figure out what data I could play with in some of the methods
This is me noting what I've seen
I think this is important so people know the `entries` are not isomorphic

:fire:  NOTE some of this is best-guess (even more reason to try documenting), and there's definitely parts missing in this.