### PR TITLE
Don't complain about missing ssb db if populatePubs has been disabled

### DIFF
--- a/src/conn-scheduler.ts
+++ b/src/conn-scheduler.ts
@@ -396,12 +396,12 @@ export class ConnScheduler {
   }
 
   private setupPubDiscovery() {
+    if (this.config.conn?.populatePubs === false) return;
+
     if (!this.hasSsbDb) {
       debug('Warning: ssb-db is missing, scheduling will miss some info');
       return;
     }
-
-    if (this.config.conn?.populatePubs === false) return;
 
     setTimeout(() => {
       if (this.closed) return;


### PR DESCRIPTION
The warning doesn't make sense if populatePubs is disabled