### PR TITLE
Allow patch-level updates to hs-network2 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "debug": "~4.1.1",
-    "has-network2": "0.0.2",
+    "has-network2": "0.0.x",
     "ip": "^1.1.5",
     "on-change-network-strict": "1.0.0",
     "on-wakeup": "^1.0.1",


### PR DESCRIPTION
ssb-conn is broken because it still picks up has-network2 0.0.2. Note that even semver range "^0.0.2" will not match 0.0.3 because of npm's special treatment of version 0.

